### PR TITLE
Add support for -i --info option

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -3,11 +3,12 @@
 'use strict';
 
 var argv = require('minimist')(process.argv.slice(2), {
-	boolean: ['all', 'help', 'multiple', 'version'],
+	boolean: ['all', 'help', 'multiple', 'info', 'version'],
 	alias: {
 		a: 'all',
 		h: 'help',
 		m: 'multiple',
+		i: 'info',
 		v: 'version'
 	}
 });

--- a/index.js
+++ b/index.js
@@ -10,7 +10,8 @@ module.exports = function (p, exec, log, cwd, tasks, options) {
 			'\nOptions:\n  -v --version   Displays app version number\n' +
 			'  -h --help      Shows this help message\n' +
 			'  -a --all       Includes pre and post scripts on the list\n' +
-			'  -m --multiple  Allows a selection of multiple tasks to run at once'
+			'  -m --multiple  Allows a selection of multiple tasks to run at once' +
+			'  -i --info      Displays the contents of each script'
 		);
 	}
 
@@ -62,7 +63,14 @@ module.exports = function (p, exec, log, cwd, tasks, options) {
 			input: p.stdin,
 			output: p.stdout
 		});
-		var promptChoices = Object.keys(tasks).filter(filterPrefixes);
+		var promptChoices = Object.keys(tasks)
+			.filter(filterPrefixes)
+			.map(function (key) {
+				return {
+					name: key + (options.info ? ': ' + tasks[key] : ''),
+					value: key
+				};
+			});
 		var promptTypes = {
 			base: {
 				type: 'list',

--- a/test/index.js
+++ b/test/index.js
@@ -99,6 +99,16 @@ test.cb(function shouldSelectPrefixedTasksWithAllFlag(t) {
 	prompt.rl.emit('line');
 });
 
+test.cb(function shouldDisplayScriptContentsWithInfoFlag(t) {
+	var testExec = function (name, args) {
+		t.is(name + ' ' + args.join(' '), 'npm run test');
+		t.end();
+	};
+	var prompt = ntl(t.context.p, testExec, log, cwd, tasks, {info: true});
+	prompt.rl.input.emit('keypress', null, {name: 'up'});
+	prompt.rl.emit('line');
+});
+
 test.cb(function shouldSelectMultipleTasksUsingFlag(t) {
 	var count = 0;
 	var testExec = function (name, args) {


### PR DESCRIPTION
First of all, great tool! I've been wanting something like this for a long time but could never find the motivation to actually do it.

I think it could be helpful to see what the scripts actually do, so this adds that ability using a `-i`/`--info` flag.