### PR TITLE
Added new line code to message for help command

### DIFF
--- a/index.js
+++ b/index.js
@@ -10,7 +10,7 @@ module.exports = function (p, exec, log, cwd, tasks, options) {
 			'\nOptions:\n  -v --version   Displays app version number\n' +
 			'  -h --help      Shows this help message\n' +
 			'  -a --all       Includes pre and post scripts on the list\n' +
-			'  -m --multiple  Allows a selection of multiple tasks to run at once' +
+			'  -m --multiple  Allows a selection of multiple tasks to run at once\n' +
 			'  -i --info      Displays the contents of each script'
 		);
 	}


### PR DESCRIPTION
Added new line code to message for help command.

*Before*
```
Usage:
  ntl [<path>]

Options:
  -v --version   Displays app version number
  -h --help      Shows this help message
  -a --all       Includes pre and post scripts on the list
  -m --multiple  Allows a selection of multiple tasks to run at once  -i --info      Displays the contents of each script
```

*After*
```
Usage:
  ntl [<path>]

Options:
  -v --version   Displays app version number
  -h --help      Shows this help message
  -a --all       Includes pre and post scripts on the list
  -m --multiple  Allows a selection of multiple tasks to run at once
  -i --info      Displays the contents of each script
```

Thanks.