### PR TITLE
Update travis config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: node_js
 node_js:
-  - "stable"
-  - '0.12'
-
+  - 4
+  - 6
+  - 8
+  - node


### PR DESCRIPTION
Getting rid of Node 0.12 and erun CI on Node 4, 6, 8 and latest.

Let me know if you still want to support Node 0.12.