### PR TITLE
Add option to show descriptions from package.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ cli options can also be invoked as their shorter alias:
 - `-m` -> `--multiple`
 - `-s` -> `--size`
 - `-i` -> `--info`
+- `-D` -> `--descriptions`
 - `-h` -> `--help`
 - `-v` -> `--version`
 
@@ -70,6 +71,7 @@ Options:
   -a, --all           Includes pre and post scripts on the list        [boolean]
   -A, --autocomplete  Starts in autocomplete mode                      [boolean]
   -d, --debug         Prints to stderr any internal error              [boolean]
+  -D, --descriptions  Displays the descriptions of each script         [boolean]
   -h, --help          Shows this help message                          [boolean]
   -i, --info          Displays the contents of each script             [boolean]
   -m, --multiple      Allows the selection of multiple items           [boolean]

--- a/README.md
+++ b/README.md
@@ -68,16 +68,16 @@ Usage:
   ntl [<path>]
 
 Options:
-  -a, --all           Includes pre and post scripts on the list        [boolean]
-  -A, --autocomplete  Starts in autocomplete mode                      [boolean]
-  -D, --debug         Prints to stderr any internal error              [boolean]
-  -d, --descriptions  Displays the descriptions of each script         [boolean]
-  -l, --limit         Limits output to scripts with a description      [boolean]
-  -h, --help          Shows this help message                          [boolean]
-  -i, --info          Displays the contents of each script             [boolean]
-  -m, --multiple      Allows the selection of multiple items           [boolean]
-  -s, --size          Amount of lines to display at once                [number]
-  -v, --version       Show version number                              [boolean]
+  -a, --all                Includes pre and post scripts on the list   [boolean]
+  -A, --autocomplete       Starts in autocomplete mode                 [boolean]
+  -D, --debug              Prints to stderr any internal error         [boolean]
+  -d, --descriptions       Displays the descriptions of each script    [boolean]
+  -o, --descriptions-only  Limits output to scripts with a description [boolean]
+  -h, --help               Shows this help message                     [boolean]
+  -i, --info               Displays the contents of each script        [boolean]
+  -m, --multiple           Allows the selection of multiple items      [boolean]
+  -s, --size               Amount of lines to display at once           [number]
+  -v, --version            Show version number                         [boolean]
 
 Visit https://github.com/ruyadorno/ntl for more info
 ```

--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ Options:
   -A, --autocomplete  Starts in autocomplete mode                      [boolean]
   -D, --debug         Prints to stderr any internal error              [boolean]
   -d, --descriptions  Displays the descriptions of each script         [boolean]
+  -l, --limit         Limits output to scripts with a description      [boolean]
   -h, --help          Shows this help message                          [boolean]
   -i, --info          Displays the contents of each script             [boolean]
   -m, --multiple      Allows the selection of multiple items           [boolean]

--- a/README.md
+++ b/README.md
@@ -70,8 +70,8 @@ Usage:
 Options:
   -a, --all           Includes pre and post scripts on the list        [boolean]
   -A, --autocomplete  Starts in autocomplete mode                      [boolean]
-  -d, --debug         Prints to stderr any internal error              [boolean]
-  -D, --descriptions  Displays the descriptions of each script         [boolean]
+  -D, --debug         Prints to stderr any internal error              [boolean]
+  -d, --descriptions  Displays the descriptions of each script         [boolean]
   -h, --help          Shows this help message                          [boolean]
   -i, --info          Displays the contents of each script             [boolean]
   -m, --multiple      Allows the selection of multiple items           [boolean]

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ cli options can also be invoked as their shorter alias:
 - `-m` -> `--multiple`
 - `-s` -> `--size`
 - `-i` -> `--info`
-- `-D` -> `--descriptions`
+- `-d` -> `--descriptions`
 - `-h` -> `--help`
 - `-v` -> `--version`
 

--- a/cli.js
+++ b/cli.js
@@ -79,7 +79,7 @@ if (argv.descriptions) {
 
 // defines the items that will be printed to the user
 const input = (argv.info || argv.descriptions
-	? Object.keys(tasks).map(i => ({ name: `${i}: ${argv.descriptions ? descriptions[i] : tasks[i]}`, value: i }))
+	? Object.keys(tasks).map(i => ({ name: `${i} — ${argv.descriptions ? descriptions[i] : tasks[i]}`, value: i }))
 	: Object.keys(tasks)
 ).filter(
 	// filter out prefixed tasks

--- a/cli.js
+++ b/cli.js
@@ -83,7 +83,7 @@ const longestScriptName = (scripts) => Object.keys(scripts).reduce((acc, curr) =
 
 // defines the items that will be printed to the user
 const input = (argv.info || argv.descriptions
-	? Object.keys(tasks).map(i => ({ name: `${i.padStart(argv.descriptionsOnly ? longestScriptName(descriptions) : longestScriptName(tasks))} › ${argv.descriptions && descriptions[i] ? descriptions[i] : tasks[i]}`, value: i }))
+	? Object.keys(tasks).map(i => ({ name: `${i.padStart(longestScriptName(argv.descriptionsOnly ? descriptions : tasks))} › ${argv.descriptions && descriptions[i] ? descriptions[i] : tasks[i]}`, value: i }))
 	: Object.keys(tasks)
 ).filter(
 	// filter out prefixed tasks

--- a/cli.js
+++ b/cli.js
@@ -21,8 +21,8 @@ const { argv } = yargs
 	.describe("D", "Prints to stderr any internal error")
 	.alias("d", "descriptions")
 	.describe("d", "Displays the descriptions of each script")
-	.alias("l", "limit")
-	.describe("l", "Limits output to scripts with a description")
+	.alias("o", "descriptions-only")
+	.describe("o", "Limits output to scripts with a description")
 	.help("h")
 	.alias("h", "help")
 	.describe("h", "Shows this help message")
@@ -33,7 +33,7 @@ const { argv } = yargs
 	.alias("s", "size")
 	.describe("s", "Amount of lines to display at once")
 	.alias("v", "version")
-	.boolean(["a", "A", "D", "d", "l", "h", "i", "m", "v"])
+	.boolean(["a", "A", "D", "d", "o", "h", "i", "m", "v"])
 	.number(["s"])
 	.epilog("Visit https://github.com/ruyadorno/ntl for more info");
 
@@ -95,7 +95,7 @@ const input = (argv.info || argv.descriptions
 ).filter(
 	// filter out tasks without a description
 	i =>
-		argv.descriptions && argv.limit
+		argv.descriptions && argv.descriptionsOnly
 			? descriptions[i.value] !== undefined
 			: true
 );

--- a/cli.js
+++ b/cli.js
@@ -5,6 +5,7 @@
 const yargs = require("yargs");
 const ipt = require("ipt");
 const out = require("simple-output");
+const pkgInfo = require("pkginfo");
 
 let tasks;
 let descriptions;
@@ -53,7 +54,7 @@ process.stdin.on("keypress", (ch, key) => {
 // get package.json scripts value
 try {
 	tasks = { exports: {} };
-	require("pkginfo")(tasks, { dir: cwd, include: ["scripts"] });
+	pkgInfo(tasks, { dir: cwd, include: ["scripts"] });
 	tasks = tasks.exports.scripts;
 } catch (e) {
 	error(e, "No package.json found");
@@ -69,7 +70,7 @@ if (!tasks || Object.keys(tasks).length < 1) {
 if (argv.descriptions) {
 	try {
 		descriptions = { exports: {} };
-		require("pkginfo")(descriptions, { dir: cwd, include: ["ntl"] });
+		pkgInfo(descriptions, { dir: cwd, include: ["ntl"] });
 		descriptions = descriptions.exports.ntl.descriptions;
 	} catch (e) {
 		error(e, "No descriptions for your npm scripts found");

--- a/cli.js
+++ b/cli.js
@@ -18,7 +18,7 @@ const { argv } = yargs
 	.alias("A", "autocomplete")
 	.describe("A", "Starts in autocomplete mode")
 	.alias("D", "debug")
-	.describe("d", "Prints to stderr any internal error")
+	.describe("D", "Prints to stderr any internal error")
 	.alias("d", "descriptions")
 	.describe("d", "Displays the descriptions of each script")
 	.help("h")

--- a/cli.js
+++ b/cli.js
@@ -16,10 +16,10 @@ const { argv } = yargs
 	.describe("a", "Includes pre and post scripts on the list")
 	.alias("A", "autocomplete")
 	.describe("A", "Starts in autocomplete mode")
-	.alias("d", "debug")
+	.alias("D", "debug")
 	.describe("d", "Prints to stderr any internal error")
-	.alias("D", "descriptions")
-	.describe("D", "Displays the descriptions of each script")
+	.alias("d", "descriptions")
+	.describe("d", "Displays the descriptions of each script")
 	.help("h")
 	.alias("h", "help")
 	.describe("h", "Shows this help message")
@@ -30,7 +30,7 @@ const { argv } = yargs
 	.alias("s", "size")
 	.describe("s", "Amount of lines to display at once")
 	.alias("v", "version")
-	.boolean(["a", "A", "d", "D", "h", "i", "m", "v"])
+	.boolean(["a", "A", "D", "d", "h", "i", "m", "v"])
 	.number(["s"])
 	.epilog("Visit https://github.com/ruyadorno/ntl for more info");
 

--- a/cli.js
+++ b/cli.js
@@ -78,16 +78,9 @@ if (argv.descriptions) {
 }
 
 // defines the items that will be printed to the user
-const input = (argv.info
-	? Object.keys(tasks).map(i => ({ name: `${i}: ${tasks[i]}`, value: i }))
-	: argv.descriptions
-		? Object.keys(tasks).map(i => {
-			return {
-				name: `${i}: ${descriptions[i]}`,
-				value: i
-			}
-		})
-		: Object.keys(tasks)
+const input = (argv.info || argv.descriptions
+	? Object.keys(tasks).map(i => ({ name: `${i}: ${argv.descriptions ? descriptions[i] : tasks[i]}`, value: i }))
+	: Object.keys(tasks)
 ).filter(
 	// filter out prefixed tasks
 	i =>

--- a/cli.js
+++ b/cli.js
@@ -21,6 +21,8 @@ const { argv } = yargs
 	.describe("D", "Prints to stderr any internal error")
 	.alias("d", "descriptions")
 	.describe("d", "Displays the descriptions of each script")
+	.alias("l", "limit")
+	.describe("l", "Limits output to scripts with a description")
 	.help("h")
 	.alias("h", "help")
 	.describe("h", "Shows this help message")
@@ -31,7 +33,7 @@ const { argv } = yargs
 	.alias("s", "size")
 	.describe("s", "Amount of lines to display at once")
 	.alias("v", "version")
-	.boolean(["a", "A", "D", "d", "h", "i", "m", "v"])
+	.boolean(["a", "A", "D", "d", "l", "h", "i", "m", "v"])
 	.number(["s"])
 	.epilog("Visit https://github.com/ruyadorno/ntl for more info");
 
@@ -73,13 +75,13 @@ if (argv.descriptions) {
 		pkgInfo(descriptions, { dir: cwd, include: ["ntl"] });
 		descriptions = descriptions.exports.ntl.descriptions;
 	} catch (e) {
-		error(e, "No descriptions for your npm scripts found");
+		console.warn("No descriptions for your npm scripts found");
 	}
 }
 
 // defines the items that will be printed to the user
 const input = (argv.info || argv.descriptions
-	? Object.keys(tasks).map(i => ({ name: `${i} — ${argv.descriptions ? descriptions[i] : tasks[i]}`, value: i }))
+	? Object.keys(tasks).map(i => ({ name: `${i} — ${argv.descriptions && descriptions[i] ? descriptions[i] : tasks[i]}`, value: i }))
 	: Object.keys(tasks)
 ).filter(
 	// filter out prefixed tasks
@@ -93,7 +95,7 @@ const input = (argv.info || argv.descriptions
 ).filter(
 	// filter out tasks without a description
 	i =>
-		argv.descriptions
+		argv.descriptions && argv.limit
 			? descriptions[i.value] !== undefined
 			: true
 );

--- a/cli.js
+++ b/cli.js
@@ -79,9 +79,11 @@ if (argv.descriptions) {
 	}
 }
 
+const longestScriptName = (scripts) => Object.keys(scripts).reduce((acc, curr) => curr.length > acc.length ? curr : acc).length;
+
 // defines the items that will be printed to the user
 const input = (argv.info || argv.descriptions
-	? Object.keys(tasks).map(i => ({ name: `${i} — ${argv.descriptions && descriptions[i] ? descriptions[i] : tasks[i]}`, value: i }))
+	? Object.keys(tasks).map(i => ({ name: `${i.padStart(argv.descriptionsOnly ? longestScriptName(descriptions) : longestScriptName(tasks))} › ${argv.descriptions && descriptions[i] ? descriptions[i] : tasks[i]}`, value: i }))
 	: Object.keys(tasks)
 ).filter(
 	// filter out prefixed tasks

--- a/test/fixtures/package.json
+++ b/test/fixtures/package.json
@@ -9,6 +9,13 @@
     "start": "echo \"start\"",
     "test": "echo \"test\""
   },
+  "ntl": {
+    "descriptions": {
+      "build": "Build task",
+      "prestart": "Pre start task",
+      "start": "Start task"
+    }
+  },
   "license": "MIT"
 }
 


### PR DESCRIPTION
Closes #4 

This adds the following option:

```
  -D, --descriptions  Displays the descriptions of each script         [boolean]
```

![image](https://user-images.githubusercontent.com/441011/39395693-dcc37998-4ae1-11e8-9632-c74656ff87fe.png)

The feature lacks a test. I’m not able to write a proper test with the current code base. Sorry, I’m not that proficient in writing test. I would prefer to split`cli.js` in a few files in a `lib` directory to make it more testable. But I guess, this is not in the scope of this PR.