### PR TITLE
Feature: Allow scripts to be excluded from interactive menu

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,13 +49,7 @@ ntl ./my-node-project
 
 ## Exclude scripts
 
-You can define a list of scrpits to be excluded from the interactive menu:
-
-```
-ntl --exclude coverall tasks
-```
-
-*package.json*
+Example *package.json*:
 ```json
 {
   "scripts": {
@@ -67,6 +61,26 @@ ntl --exclude coverall tasks
 }
 ```
 
+You can define a list of scripts to be excluded from the interactive menu:
+
+```
+$ ntl --exclude coverall tasks
+✔  Npm Task List - v3.0.0
+? Select a task to run: (Use arrow keys)
+❯ test
+  test:watch
+  coveralls
+```
+
+You can also use a wildcard character to exclude multiple scripts with one string:
+
+```
+$ ntl --exclude "test*"
+✔  Npm Task List - v3.0.0
+? Select a task to run: (Use arrow keys)
+❯ coveralls
+  tasks
+```
 
 <br />
 

--- a/README.md
+++ b/README.md
@@ -47,6 +47,29 @@ ntl ./my-node-project
 
 <br />
 
+## Exclude scripts
+
+You can define a list of scrpits to be excluded from the interactive menu:
+
+```
+ntl --exclude coverall tasks
+```
+
+*package.json*
+```json
+{
+  "scripts": {
+    "test": "jest --coverage",
+    "test:watch": "jest --coverage --watchAll",
+    "coveralls": "jest --coverage --coverageReporters=text-lcov | coveralls",
+    "tasks": "ntl --exclude coverall tasks"
+  }
+}
+```
+
+
+<br />
+
 ## Using task descriptions
 
 You can define descriptions for your tasks in your `package.json` file by defining a `ntl` section, e.g:
@@ -76,6 +99,7 @@ cli options can also be invoked as their shorter alias:
 - `-s` -> `--size`
 - `-i` -> `--info`
 - `-d` -> `--descriptions`
+- `-e` -> `--exclude`
 - `-h` -> `--help`
 - `-v` -> `--version`
 
@@ -92,6 +116,7 @@ Options:
   -A, --autocomplete       Starts in autocomplete mode                 [boolean]
   -D, --debug              Prints to stderr any internal error         [boolean]
   -d, --descriptions       Displays the descriptions of each script    [boolean]
+  -e, --exclude            Excludes specific scripts                     [array]
   -o, --descriptions-only  Limits output to scripts with a description [boolean]
   -h, --help               Shows this help message                     [boolean]
   -i, --info               Displays the contents of each script        [boolean]

--- a/cli.js
+++ b/cli.js
@@ -104,7 +104,11 @@ const input = (argv.info || argv.descriptions
 		argv.descriptions && argv.descriptionsOnly
 			? descriptions[i.value] !== undefined
 			: true
-).filter(i => argv.exclude && argv.exclude.includes(i) ? false : true);
+).filter(
+	// filter excluded scripts
+	i =>
+		!argv.exclude || !argv.exclude.some(e => new RegExp(e + (e.includes('*') ? '' : '$'), 'i').test(i))
+);
 
 out.success("Npm Task List - v" + pkg.version);
 

--- a/cli.js
+++ b/cli.js
@@ -104,8 +104,7 @@ const input = (argv.info || argv.descriptions
 		argv.descriptions && argv.descriptionsOnly
 			? descriptions[i.value] !== undefined
 			: true
-);
-	.filter(i => (argv.exclude.includes(i) ? false : true));
+).filter(i => (argv.exclude.includes(i) ? false : true));
 
 out.success("Npm Task List - v" + pkg.version);
 

--- a/cli.js
+++ b/cli.js
@@ -104,7 +104,7 @@ const input = (argv.info || argv.descriptions
 		argv.descriptions && argv.descriptionsOnly
 			? descriptions[i.value] !== undefined
 			: true
-).filter(i => (argv.exclude.includes(i) ? false : true));
+).filter(i => argv.exclude && argv.exclude.includes(i) ? false : true);
 
 out.success("Npm Task List - v" + pkg.version);
 

--- a/cli.js
+++ b/cli.js
@@ -105,6 +105,7 @@ const input = (argv.info || argv.descriptions
 			? descriptions[i.value] !== undefined
 			: true
 );
+	.filter(i => (argv.exclude.includes(i) ? false : true));
 
 out.success("Npm Task List - v" + pkg.version);
 

--- a/cli.js
+++ b/cli.js
@@ -29,6 +29,8 @@ const { argv } = yargs
 	.describe("h", "Shows this help message")
 	.alias("i", "info")
 	.describe("i", "Displays the contents of each script")
+	.alias("e", "exclude")
+	.describe("e", "Excludes specific scripts")
 	.alias("m", "multiple")
 	.describe("m", "Allows the selection of multiple items")
 	.alias("s", "size")
@@ -36,6 +38,7 @@ const { argv } = yargs
 	.alias("v", "version")
 	.boolean(["a", "A", "D", "d", "o", "h", "i", "m", "v"])
 	.number(["s"])
+	.array(["e"])
 	.epilog("Visit https://github.com/ruyadorno/ntl for more info");
 
 const pkg = require("./package");

--- a/test/fixtures/package.json
+++ b/test/fixtures/package.json
@@ -5,6 +5,7 @@
   "scripts": {
     "build": "echo \"build\"",
     "debug": "echo \"debug\"",
+    "debugger": "echo \"debugger\"",
     "prestart": "echo \"prestart\"",
     "start": "echo \"start\"",
     "test": "echo \"test\""

--- a/test/index.js
+++ b/test/index.js
@@ -119,6 +119,31 @@ test.cb(function shouldWorkFromCliWithParams(t) {
 	run.stdin.end();
 });
 
+test.cb(function shouldWorkFromCliExcludedScript(t) {
+	var content = "";
+	var run = spawn("node", ["../cli.js", "./fixtures", "--exclude", "debug"], {
+		cwd: cwd
+	});
+	run.stdout.on("data", function(data) {
+		content += data.toString();
+	});
+	run.stderr.on("data", function(data) {
+		console.error(data.toString());
+	});
+	run.on("close", function(code) {
+		if (code !== 0) {
+			t.fail();
+		}
+		t.is(/debug/gm.test(content), false);
+		t.end();
+	});
+	run.stdin.write("j");
+	run.stdin.write("j");
+	run.stdin.write(" ");
+	run.stdin.write("\n");
+	run.stdin.end();
+});
+
 test.cb(function shouldExitWithErrorCodeOnNoPackageJson(t) {
 	tempdir()
 		.then(function(foldername) {

--- a/test/index.js
+++ b/test/index.js
@@ -109,7 +109,7 @@ test.cb(function shouldWorkFromCliWithParams(t) {
 			t.fail();
 		}
 		var values = content.split("\n");
-		t.is("prestart", values[values.length - 2]);
+		t.is("debugger", values[values.length -2]);
 		t.end();
 	});
 	run.stdin.write("j");
@@ -121,7 +121,7 @@ test.cb(function shouldWorkFromCliWithParams(t) {
 
 test.cb(function shouldWorkFromCliExcludedScript(t) {
 	var content = "";
-	var run = spawn("node", ["../cli.js", "./fixtures", "--exclude", "debug"], {
+	var run = spawn("node", ["../cli.js", "./fixtures", "--exclude", "debug*"], {
 		cwd: cwd
 	});
 	run.stdout.on("data", function(data) {
@@ -134,7 +134,7 @@ test.cb(function shouldWorkFromCliExcludedScript(t) {
 		if (code !== 0) {
 			t.fail();
 		}
-		t.is(/debug/gm.test(content), false);
+		t.is(/debug./gm.test(content), false);
 		t.end();
 	});
 	run.stdin.write("j");


### PR DESCRIPTION
Hej @ruyadorno,

here is the pull request which closes #8.

As said:
> We have decided to name the option `-e` --> `--exclude` to prevent an alias name clash with `-i` -> `--info`.

Here’s a feature summary taken from the updated README:

> ## Exclude scripts
>
>Example *package.json*:
>```json
>{
>  "scripts": {
>    "test": "jest --coverage",
>    "test:watch": "jest --coverage --watchAll",
>    "coveralls": "jest --coverage --coverageReporters=text-lcov | coveralls",
>    "tasks": "ntl --exclude coverall tasks"
>  }
>}
>```
>
>You can define a list of scripts to be excluded from the interactive menu:
>
>```
>$ ntl --exclude coverall tasks
>✔  Npm Task List - v3.0.0
>? Select a task to run: (Use arrow keys)
>❯ test
>  test:watch
>  coveralls
>```
>
>You can also use a wildcard character to exclude multiple scripts with one string:
>
>```
>$ ntl --exclude "test*"
>✔  Npm Task List - v3.0.0
>? Select a task to run: (Use arrow keys)
>❯ coveralls
>  tasks
>```