### PR TITLE
Fix excluding scripts when showing descriptions or scripts contents

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -104,7 +104,7 @@ const input = (argv.info || argv.descriptions
 ).filter(
 	// filter excluded scripts
 	i =>
-		!argv.exclude || !argv.exclude.some(e => new RegExp(e + (e.includes('*') ? '' : '$'), 'i').test(i))
+		!argv.exclude || !argv.exclude.some(e => new RegExp(e + (e.includes('*') ? '' : '$'), 'i').test(argv.info || argv.descriptions ? i.value : i))
 );
 
 out.success("Npm Task List - v" + pkg.version);


### PR DESCRIPTION
Fixes #41 

The `--exclude` option now works with `--info` and `--descriptions` 🙈 

![image](https://user-images.githubusercontent.com/441011/54569458-4113e880-49db-11e9-8f63-e7a79e3df504.png)
