### PR TITLE
Add 'npm-tasklist' command as a longhand option for starting ntl

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,11 @@ just run it at once using **npx**:
 npx ntl
 ```
 
+There's also a longhand command you can run if you experience conflicts:
+```sh
+npx npm-tasklist
+```
+
 <br />
 
 ## Usage
@@ -43,6 +48,12 @@ You can also specify a project folder containing a `package.json` file:
 
 ```sh
 ntl ./my-node-project
+```
+
+Longhand project folder example:
+
+```sh
+npm-tasklist ./my-node-project
 ```
 
 <br />

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "ntl",
-  "version": "3.2.4",
+  "version": "3.2.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,13 +1,16 @@
 {
   "name": "ntl",
-  "version": "3.2.4",
+  "version": "3.2.5",
   "description": "Npm Task List: Interactive cli menu to list/run npm tasks",
   "repository": "ruyadorno/ntl",
   "author": {
     "name": "Ruy Adorno",
     "url": "http://ruyadorno.com"
   },
-  "bin": "cli.js",
+  "bin": {
+    "ntl": "cli.js",
+    "npm-tasklist": "cli.js"
+  },
   "engines": {
     "node": ">=8.0.0"
   },


### PR DESCRIPTION
Closes #46 

## Description

This PR adds a new `npm-tasklist` option that can be used as an alternative to `ntl` when initiating the tool.

## Changes

- Added longhand example(s) to readme
- Modified `package.json` `bin` starting scripts
- Bumped npm version