### PR TITLE
Added custom runner options

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,26 @@ npm-tasklist ./my-node-project
 
 <br />
 
+## Custom runner
+
+If you want to use a custom runner, e.g: `yarn` you can either use a environment variable:
+
+```sh
+NTL_RUNNER=yarn ntl
+```
+
+OR you can also define a `runner` property in the `ntl` configuration within your `package.json`:
+
+```json
+{
+  "ntl": {
+    "runner": "yarn"
+  }
+}
+```
+
+<br />
+
 ## Exclude scripts
 
 Example *package.json*:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "ntl",
-  "version": "3.2.5",
+  "version": "3.2.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ntl",
-  "version": "3.2.5",
+  "version": "3.2.4",
   "description": "Npm Task List: Interactive cli menu to list/run npm tasks",
   "repository": "ruyadorno/ntl",
   "author": {

--- a/test/fixtures/custom-runner/package.json
+++ b/test/fixtures/custom-runner/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "foo",
+  "version": "1.0.0",
+  "description": "Lorem ipsum dolor sit amet",
+  "scripts": {
+    "build": "echo \"build\"",
+    "debug": "echo \"debug\"",
+    "debugger": "echo \"debugger\"",
+    "prestart": "echo \"prestart\"",
+    "start": "echo \"start\"",
+    "test": "echo \"test\""
+  },
+  "ntl": {
+    "runner": "echo",
+    "descriptions": {
+      "build": "Build task",
+      "prestart": "Pre start task",
+      "start": "Start task"
+    }
+  },
+  "license": "MIT"
+}
+

--- a/test/fixtures/missing-descriptions/package.json
+++ b/test/fixtures/missing-descriptions/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "foo",
+  "version": "1.0.0",
+  "description": "Lorem ipsum dolor sit amet",
+  "scripts": {
+    "build": "echo \"build\"",
+    "debug": "echo \"debug\"",
+    "debugger": "echo \"debugger\"",
+    "prestart": "echo \"prestart\"",
+    "start": "echo \"start\"",
+    "test": "echo \"test\""
+  },
+  "ntl": {
+    "runner": "echo"
+  },
+  "license": "MIT"
+}
+

--- a/test/index.js
+++ b/test/index.js
@@ -182,3 +182,80 @@ test.cb('should exit with error msg on malformed package.json', t => {
 		t.end();
 	});
 });
+
+test.cb('should print warn msg if using descriptions option but none found on package.json', t => {
+	var content = "";
+	var run = spawn("node", [path.join(__dirname, "..", "cli.js"), "--descriptions"], {
+		cwd: path.join(__dirname, "/fixtures/missing-descriptions")
+	});
+	run.stdout.on("data", function(data) {
+		content += data.toString();
+	});
+	run.stderr.on("data", function(data) {
+		console.error(data.toString());
+		t.fail();
+	});
+	run.on("close", function(code) {
+		if (code !== 0) {
+			t.fail();
+		}
+		var values = content.split("\n");
+		var expected = values[0];
+		t.is("⚠  No descriptions for your echo scripts found", expected);
+		t.end();
+	});
+	run.stdin.write("\n");
+	run.stdin.end();
+});
+
+test.cb('should work with custom runner env variable', t => {
+	var content = "";
+	var run = spawn("node", ["../cli.js", "./fixtures"], {
+		cwd: path.join(__dirname),
+		env: {
+			NTL_RUNNER: 'echo',
+			...process.env
+		}
+	});
+	run.stdout.on("data", function(data) {
+		content += data.toString();
+	});
+	run.stderr.on("data", function(data) {
+		console.error(data.toString());
+	});
+	run.on("close", function(code) {
+		if (code !== 0) {
+			t.fail();
+		}
+		var values = content.split("\n");
+		var expected = values[values.length - 2];
+		t.is("run build", expected);
+		t.end();
+	});
+	run.stdin.write("\n");
+	run.stdin.end();
+});
+
+test.cb('should work with custom runner property', t => {
+	var content = "";
+	var run = spawn("node", ["../cli.js", "./fixtures/custom-runner"], {
+		cwd: path.join(__dirname)
+	});
+	run.stdout.on("data", function(data) {
+		content += data.toString();
+	});
+	run.stderr.on("data", function(data) {
+		console.error(data.toString());
+	});
+	run.on("close", function(code) {
+		if (code !== 0) {
+			t.fail();
+		}
+		var values = content.split("\n");
+		var expected = values[values.length - 2];
+		t.is("run build", expected);
+		t.end();
+	});
+	run.stdin.write("\n");
+	run.stdin.end();
+});


### PR DESCRIPTION
- Breaking change: missing descriptions upon using `--descriptions` flag will now only throw a warning instead of error+exit
- Adds ability to use a custom runner using both methods:

### Env variable

```sh
export NTL_RUNNER=yarn
ntl
```

### package.json

`ntl.runner`property inside your current working dir `package.json` file:

```json
{
  "ntl": {
    "runner": "yarn"
  }
}
```