### PR TITLE
--no-rerun-cache logic fix

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -60,7 +60,7 @@ const {
 	autocomplete,
 	multiple,
 	ordered,
-	noRerunCache,
+	rerunCache,
 	rerun,
 	rerunCacheDir,
 	rerunCacheName,
@@ -71,7 +71,7 @@ const runner = (ntl && ntl.runner) || process.env.NTL_RUNNER || defaultRunner;
 const { descriptions = {} } = ntl || {};
 const scriptKeys = Object.keys(scripts || {});
 const noScriptsFound = !scripts || scriptKeys.length < 1;
-const avoidCache = noRerunCache || process.env.NTL_NO_RERUN_CACHE;
+const avoidCache = rerunCache === false || process.env.NTL_NO_RERUN_CACHE;
 const shouldRerun = !avoidCache && (rerun || process.env.NTL_RERUN);
 
 // Exits program execution on ESC


### PR DESCRIPTION
https://github.com/ruyadorno/ntl/issues/72

The way yargs works is actually that the argument `--no-rerun-cache` gets pulled through as `rerunCache: false`